### PR TITLE
Add needed imports in models.py

### DIFF
--- a/util/models.py
+++ b/util/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, SmallInteger, PrimaryKeyConstraint
 from sqlalchemy.ext.declarative import declarative_base
 
 Base = declarative_base()


### PR DESCRIPTION
models.py에 사용되었지만 import되지 않은 `SmallInteger`와 `PrimaryKeyConstraint`를 import에 추가했습니다.