### PR TITLE
Implement /board/<board_id>

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,7 +56,7 @@ def board_id(uid: str, board_id: str):
         offset = request.args.get('offset', -1, type=int)
         limit = request.args.get('limit', -1, type=int)
         
-        if offset == -1 or limit == -1: # offset 또는 limit이 없음
+        if offset < 0 or limit < 0: # offset 또는 limit이 없거나 음수임
             return {"message": "Invalid range"}, 404
         
         result = board_get(uid, board_id, offset, limit)

--- a/app.py
+++ b/app.py
@@ -65,7 +65,7 @@ def board_id(uid: str, board_id: str):
         
         return result, 200
     except: # offset 또는 limit이 숫자가 아님
-        return {"message": "Invalid board_id"}, 400
+        return {"message": "Invalid range"}, 404
 
 @app.route('/post/<post_id>')
 @get_uid

--- a/app.py
+++ b/app.py
@@ -47,7 +47,25 @@ def board(uid: str):
 @app.route('/board/<board_id>')
 @get_uid
 def board_id(uid: str, board_id: str):
-    pass
+    try:
+        if not board_id.isnumeric(): # 숫자가 아닌 board_id
+            return {"message": "Board does not exist"}, 404
+        
+        board_id = int(board_id)
+        
+        offset = request.args.get('offset', -1, type=int)
+        limit = request.args.get('limit', -1, type=int)
+        
+        if offset == -1 or limit == -1: # offset 또는 limit이 없음
+            return {"message": "Invalid range"}, 404
+        
+        result = board_get(uid, board_id, offset, limit)
+        if isinstance(result, ErrorObject):
+            return result.get_response()
+        
+        return result, 200
+    except: # offset 또는 limit이 숫자가 아님
+        return {"message": "Invalid board_id"}, 400
 
 @app.route('/post/<post_id>')
 @get_uid

--- a/modules/board.py
+++ b/modules/board.py
@@ -1,3 +1,5 @@
+from flask import jsonify
+
 import util.db as db
 from util.error_object import ErrorObject
 
@@ -34,17 +36,31 @@ def board_get(uid: str, board_id: int, offset: int, limit: int) -> dict | ErrorO
     #   dict | ErrorObject: board_info | ErrorObject
     # --------------------------------------------------
     # DB에서 board_id로 지정된 board의 metadata 반환
+    metadata = db.get_board_metadata(board_id)
+    if isinstance(metadata, db.SQLAlchemyError):
+        return ErrorObject(503, 'DB Error:' + metadata._message())
     
     # 결과가 없다면
+    if metadata == None:
         # return ErrorObject(404)
+        return ErrorObject(404, 'Board does not exist')
     
     # DB에서 board_id로 지정된 board의 post 중 ID 역순으로 offset부터 limit개의 게시글 목록 반환
+    posts = db.get_board_posts(board_id, offset, limit)
+    if isinstance(posts, db.SQLAlchemyError):
+        return ErrorObject(503, 'DB Error:' + posts._message())
     
     # 게시글 목록이 없다면
+    if len(posts) == 0:
         # 게시글 갯수 반환
+        posts_count = db.get_board_posts_count(board_id)
+        if isinstance(posts_count, db.SQLAlchemyError):
+            return ErrorObject(503, 'DB Error:' + posts_count._message())
         
         # offset이 게시글 갯수보다 크다면
+        if offset >= posts_count:
             # return ErrorObject(404)
+            return ErrorObject(404, 'Out of range')
     
     # return 게시판 정보
-    pass
+    return jsonify(metadata=metadata, posts=posts)

--- a/modules/board.py
+++ b/modules/board.py
@@ -62,5 +62,5 @@ def board_get(uid: str, board_id: int, offset: int, limit: int) -> dict | ErrorO
             # return ErrorObject(404)
             return ErrorObject(404, 'Out of range')
     
-    # return 게시판 정보
+    # return 게시판 정보 및 게시글 목록
     return jsonify(metadata=metadata, posts=posts)

--- a/util/db.py
+++ b/util/db.py
@@ -4,6 +4,8 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from models import *
 
+from typing import List
+
 engine = create_engine('') # TODO: Add database URL
 Session = sessionmaker(bind=engine)
 
@@ -30,3 +32,54 @@ def _execute_sql(sql: str) -> dict | SQLAlchemyError:
 # --------------------------------------------------
 
 # etc.
+
+def get_board_metadata(board_id: int) -> Board | SQLAlchemyError | None:
+    res: Board | SQLAlchemyError | None
+    
+    with Session() as session:
+        try:
+            res = session.query(Board) \
+                    .filter(Board.id == board_id) \
+                    .first()
+        
+        except SQLAlchemyError as e:
+            session.rollback()
+            res = e
+    
+    return res
+
+# board_id로 지정된 board의 metadata와 offset과 limit으로 지정된 범위의 게시글 목록을 반환합니다
+def get_board_posts(board_id: int, offset: int, limit: int) -> List[Post] | SQLAlchemyError:
+    # get_board_metadata 호출 후 사용하기 때문에 board_id로 지정된 board가 존재한다고 가정합니다
+    res: List[Post] | SQLAlchemyError
+    
+    with Session() as session:
+        try:
+            res = session.query(Post) \
+                    .filter(Post.board_id == board_id) \
+                    .order_by(Post.id.desc()) \
+                    .offset(offset) \
+                    .limit(limit) \
+                    .all()
+        
+        except SQLAlchemyError as e:
+            session.rollback()
+            res = e
+
+    return res
+
+def get_board_posts_count(board_id: int) -> int | SQLAlchemyError:
+    # get_board_metadata 호출 후 사용하기 때문에 board_id로 지정된 board가 존재한다고 가정합니다
+    res: int | SQLAlchemyError
+    
+    with Session() as session:
+        try:
+            res = session.query(Post) \
+                    .filter(Post.board_id == board_id) \
+                    .count()
+        
+        except SQLAlchemyError as e:
+            session.rollback()
+            res = e
+    
+    return res


### PR DESCRIPTION
`/board/<board_id>`에 대한 DB / logic / routing 3가지 구현했습니다.

#11 과 구현 내용 크게 차이 없으며, 해당 PR과 같이 SQLAlchemy의 Session Query 기반 DB 조작 방법 시도해보았고 DB 오류 시 503 및 DB 자체 에러 메시지 출력하도록 설정했습니다. 추후 DB 오류 메시지 형태 설정되면 그에 맞춰 일괄적으로 고치면 될 것 같습니다. 나머지 오류는 notion의 문서 기반하여 처리했습니다.