### PR TITLE
Remove cd statements in bash

### DIFF
--- a/start_deploy.sh
+++ b/start_deploy.sh
@@ -1,4 +1,3 @@
 #!/usr/bin
 
-cd ./deploy
 uwsgi --http 127.0.0.1:6000 -w app:app --ini app.ini:deploy

--- a/start_dev.sh
+++ b/start_dev.sh
@@ -1,4 +1,3 @@
 #!/usr/bin
 
-cd ./${1}
-uwsgi --http 127.0.0.1:{2} -w app:app --ini app.ini:dev
+uwsgi --http 127.0.0.1:{1} -w app:app --ini app.ini:dev


### PR DESCRIPTION
서버 폴더 바깥에 두는 대신 bash를 서버 디렉토리 내부로 옮기면서 cd 문을 삭제했어야 했는데 앞의 commit에서 고치지 않아 수정했습니다.