### PR TITLE
import 없이 SQLAlchemyError 사용 수정

### DIFF
--- a/modules/post.py
+++ b/modules/post.py
@@ -83,7 +83,7 @@ def post_upload(uid: str, title: str, content: str, board_id: int, image: str | 
         result = db._execute_sql(upload_post_sql)
         return result.lastrowid
     
-    except SQLAlchemyError as e:
+    except db.SQLAlchemyError as e:
         return ErrorObject(500, str(e))
 
 # /post/like


### PR DESCRIPTION
post.py에 SQLAlchemyError import 없이 그대로 사용하는 코드가 있어서 수정했습니다.