### PR TITLE
게시판이 하나도 없을 시 항상 에러를 반환하는 오류 수정

### DIFF
--- a/modules/board.py
+++ b/modules/board.py
@@ -26,7 +26,7 @@ def board_list(offset: int, limit: int) -> dict | ErrorObject:
             return ErrorObject(500, 'DB Error: ' + str(board_size))
         
         # offset이 게시판 갯수보다 크다면
-        if offset >= board_size:
+        if offset >= board_size and board_size != 0:
             # ErrorObject 반환(404)
             return ErrorObject(404, 'Out of range')
     


### PR DESCRIPTION
게시판 데이터가 존재하지 않을 때 `/board` API를 호출하면 `offset`과 `limit`이 어느 값이어도 정상 응답을 반환하는 경우가 없습니다. 따라서 게시판 데이터가 없을 때에는 빈 게시판 데이터를 허용하도록 수정했습니다.