### PR TITLE
댓글을 시간 순으로 정렬

### DIFF
--- a/util/db.py
+++ b/util/db.py
@@ -185,7 +185,7 @@ def get_comment_like_counts(comment_ids: List[int]) -> List[int] | SQLAlchemyErr
                     .filter(CommentLike.comment_id.in_(comment_ids)) \
                     .group_by(CommentLike.comment_id) \
                     .with_entities(CommentLike.comment_id, func.count(CommentLike.comment_id)) \
-                    .order_by(CommentLike.comment_id.desc()) \
+                    .order_by(CommentLike.comment_id.asc()) \
                     .all()
         except SQLAlchemyError as e:
             session.rollback()

--- a/util/db.py
+++ b/util/db.py
@@ -90,7 +90,7 @@ def get_post_comments(post_id: int) -> dict | SQLAlchemyError:
             res["comments"] = session.query(Comment, User.name.label('user')) \
                     .outerjoin(User, Comment.user_id == User.id) \
                     .filter(Comment.post_id == post_id) \
-                    .order_by(Comment.id.desc()) \
+                    .order_by(Comment.id.asc()) \
                     .all()
         except SQLAlchemyError as e:
             session.rollback()


### PR DESCRIPTION
기존 코드에서는 댓글이 시간의 역순, 즉 최신 댓글이 먼저 나오도록 되어있었습니다. 이는 일반적인 커뮤니티의 순서와 맞지 않아 오래된 댓글부터 보이도록 적용했습니다.

또한 #51 에 기존 댓글 순서와 맞추기 위해 시간의 역순으로 댓글을 조회한 코드가 있는데, 해당 PR merge 되면 해당 코드도 같이 수정하도록 하겠습니다.