### PR TITLE
Response의 id 관련 키 통일

### DIFF
--- a/app.py
+++ b/app.py
@@ -117,7 +117,7 @@ def post_upload_(uid: str):
     if isinstance(result, ErrorObject):
         return result.get_response()
     
-    return {"id": result}, 200
+    return {"post_id": result}, 200
 
 @app.route('/post/like', methods=['POST'])
 @get_uid
@@ -148,7 +148,7 @@ def comment_upload_(uid: str):
     
     if isinstance(result, ErrorObject):
         return result.get_response()
-    return {"id": result}, 200
+    return {"comment_id": result}, 200
 
 @app.route('/comment/delete', methods=['POST'])
 @get_uid


### PR DESCRIPTION
routing function의 response 쪽의 id 키가 통일되어있지 않아 모두 `post_id`와 `comment_id`로 통일시켰습니다.