### PR TITLE
좋아요 계산 코드 수정

### DIFF
--- a/modules/board.py
+++ b/modules/board.py
@@ -110,7 +110,13 @@ def board_get(board_id: int, offset: int, limit: int) -> dict | ErrorObject:
         return ErrorObject(500, 'DB Error:' + str(post_likes))
     
     for i in range(len(post_data)):
-        post_data[i]['likes'] = post_likes[i]
+        post_data[i]['likes'] = 0
+    
+    for i in range(len(post_likes)):
+        like = post_likes[i]
+        for j in range(len(post_data)):
+            if post_data[j]['post_id'] == like[0]:
+                post_data[j]['likes'] = like[1]
 
     # return 게시판 정보 및 게시글 목록
     return jsonify(metadata=data, posts=post_data)

--- a/modules/post.py
+++ b/modules/post.py
@@ -63,7 +63,13 @@ def post_get(post_id: int) -> dict | ErrorObject:
         return ErrorObject(500, "DB Error: " + str(comment_like))
     
     for i in range(len(result["comments"])):
-        result["comments"][i]["like"] = comment_like[i]
+        result["comments"][i]["likes"] = 0
+    
+    for i in range(len(comment_like)):
+        like = comment_like[i]
+        for j in range(len(result["comments"])):
+            if result["comments"][j]["comment_id"] == like[0]:
+                result["comments"][j]["likes"] = like[1]
     
     return jsonify(result)
 


### PR DESCRIPTION
board.py 및 post.py에서 각각 게시글의 좋아요 갯수와 댓글의 좋아요 갯수를 계산하던 코드를 고쳤습니다. DB에 좋아요 내역이 없는 경우 `(ID, 0)`이 나오는 것이 아니라 아예 해당 원소가 나오지 않아 생겼던 버그입니다.