### PR TITLE
Fix wrong loop range in board_get

### DIFF
--- a/modules/board.py
+++ b/modules/board.py
@@ -92,7 +92,7 @@ def board_get(board_id: int, offset: int, limit: int) -> dict | ErrorObject:
     }
     
     post_data = []
-    for post in post_data:
+    for post in posts:
         post = post.tuple()
         post_data.append({
             'post_id': post[0].id,


### PR DESCRIPTION
`board_get` 함수에서 게시글을 순회하는 루프의 범위로 설정된 변수가 잘못되어있어 수정했습니다.