### PR TITLE
get_board_posts 리턴 타입 수정

### DIFF
--- a/util/db.py
+++ b/util/db.py
@@ -7,7 +7,7 @@ import os
 
 from util.models import *
 
-from typing import List
+from typing import List, Tuple
 
 DB_URL = f"mysql+mysqlconnector://{os.environ.get('USER')}:{os.environ.get('PASSWORD')}@{os.environ.get('HOST')}:{os.environ.get('PORT')}/{os.environ.get('DATABASE')}?charset=utf8mb4&collation=utf8mb4_general_ci"
 
@@ -223,7 +223,7 @@ def get_board_list_size() -> int | SQLAlchemyError:
     return count
 
 # board_id로 지정된 board의 metadata와 offset과 limit으로 지정된 범위의 게시글 목록과 작성자 이름을 반환합니다
-def get_board_posts(board_id: int, offset: int, limit: int) -> List[Row[Post, User.name]] | SQLAlchemyError:
+def get_board_posts(board_id: int, offset: int, limit: int) -> List[Row[Tuple[Post, str]]] | SQLAlchemyError:
     # get_board_metadata 호출 후 사용하기 때문에 board_id로 지정된 board가 존재한다고 가정합니다
     res: List[Row[Post, User.name]] | SQLAlchemyError
     


### PR DESCRIPTION
db.py의 `get_board_posts` 함수의 리턴 타입이 잘못되어있어서 런타임에서 index 에러가 발생했습니다. 이를 알맞은 타입으로 수정했습니다.