### PR TITLE
psutil.virtual.memory() 오타 수정

### DIFF
--- a/modules/chatbot.py
+++ b/modules/chatbot.py
@@ -31,7 +31,7 @@ def chatbot_log(uid: str) -> dict | ErrorObject:
     #   dict | ErrorObject: log | ErrorObject
 
     # check current memory usage by psutil
-    memory_usage = psutil.virtual.memory().percent
+    memory_usage = psutil.virtual_memory().percent
     if memory_usage > 90:
         return ErrorObject(500, "Memory exceeded, cannot create new chatbot instances")
 


### PR DESCRIPTION
메모리 검사 코드에서 `psutil.virtual.memory()`로 되어있어 `/chatbot/log` 호출 시 500 에러가 발생했습니다. API 참조 후 알맞은 함수인 `virtual_memory()`로 수정했습니다.