### PR TITLE
POST 데이터 참조 불가 오류 수정

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import sys
+import json
 
 from flask import Flask, render_template, request
 
@@ -102,16 +103,23 @@ def post_id(post_id: str):
 @app.route('/post/upload', methods=['POST'])
 @get_uid
 def post_upload_(uid: str):
-    title = request.args.get('title', '', type=str)
-    content = request.args.get('content', '', type=str)
-    board_id = request.args.get('board_id', type=int)
-    image = request.args.get('image', None, type=str)
+    args: dict = json.loads(request.data)
+    
+    title = args.get('title', '')
+    content = args.get('content', '')
+    board_id = args.get('board_id', None)
+    image = args.get('image', None)
     
     if board_id is None:
         return {"message": "No board specified"}, 404
     
     if len(title) == 0 or len(content) == 0:
         return {"message": "Empty content"}, 404
+    
+    try:
+        board_id = int(board_id)
+    except: # board_id가 숫자가 아님
+        return {"message": "Board does not exist"}, 404
     
     if image is not None and len(image) == 0:
         image = None
@@ -125,10 +133,17 @@ def post_upload_(uid: str):
 @app.route('/post/like', methods=['POST'])
 @get_uid
 def post_like_(uid: str):
-    post_id = request.args.get('post_id', type=int)
+    args: dict = json.loads(request.data)
+    
+    post_id = args.get('post_id', None)
     
     if post_id is None: # post_id가 없음
         return {"message": "No post specified"}, 404
+    
+    try:
+        post_id = int(post_id)
+    except: # post_id가 숫자가 아님
+        return {"message": "Post does not exist"}, 404
     
     result = post_like(uid, post_id)
     if isinstance(result, ErrorObject):
@@ -139,13 +154,20 @@ def post_like_(uid: str):
 @app.route('/comment/upload', methods=['POST'])
 @get_uid
 def comment_upload_(uid: str):
-    content = request.args.get('content', '', type=str)
-    post_id = request.args.get('post_id', type=int)
+    args: dict = json.loads(request.data)
+    
+    content = args.get('content', '')
+    post_id = args.get('post_id', None)
     
     if post_id is None: # post_id가 없음
         return {"message": "No post specified"}, 404
     if len(content) == 0: # content가 없음
         return {"message": "Empty comment"}, 404
+    
+    try:
+        post_id = int(post_id)
+    except:
+        return {"message": "Post does not exist"}, 404
     
     result = comment_upload(uid, content, post_id)
     
@@ -156,10 +178,17 @@ def comment_upload_(uid: str):
 @app.route('/comment/delete', methods=['POST'])
 @get_uid
 def comment_delete_(uid: str):
-    comment_id = request.args.get('comment_id', type=int)
+    args: dict = json.loads(request.data)
+    
+    comment_id = args.get('comment_id', None)
     
     if comment_id is None: # comment_id가 없음
         return {"message": "No comment specified"}, 404
+    
+    try:
+        comment_id = int(comment_id)
+    except: # comment_id가 숫자가 아님
+        return {"message": "Comment does not exist"}, 404
     
     result = comment_delete(uid, comment_id)
     if isinstance(result, ErrorObject):
@@ -170,10 +199,17 @@ def comment_delete_(uid: str):
 @app.route('/comment/like', methods=['POST'])
 @get_uid
 def comment_like_(uid: str):
-    comment_id = request.args.get('comment_id', type=int)
+    args: dict = json.loads(request.data)
+    
+    comment_id = args.get('comment_id', None)
     
     if comment_id is None: # comment_id가 없음
         return {"message": "No comment specified"}, 404
+    
+    try:
+        comment_id = int(comment_id)
+    except: # comment_id가 숫자가 아님
+        return {"message": "Comment does not exist"}, 404
     
     result = comment_like(uid, comment_id)
     if isinstance(result, ErrorObject):
@@ -184,8 +220,10 @@ def comment_like_(uid: str):
 @app.route('/chatbot/send', methods=['POST'])
 @get_uid
 def chatbot_send_(uid: str):
-    message = request.args.get('message', type=str)
-    image = request.args.get('image', type=str) #image temporary
+    args: dict = json.loads(request.data)
+    
+    message = args.get('message', '')
+    image = args.get('image', None) #image temporary
     
     result = chatbot_send(uid, message, image)
     


### PR DESCRIPTION
모든 요청에 대해 `request.args`를 활용하여 받은 데이터를 활용하는 코드를 짰었는데, POST는 GET과 다르게 query가 아니라 body로 오기 때문에 다른 방법을 사용하는 것이 맞았습니다. GET에서는 `request.args`를 사용했다면 POST에서는 `request.data`를 사용하여 클라이언트가 보낸 데이터를 사용할 수 있었습니다. POST 요청에 대하여 해당 사항 수정했습니다. 또한 해당 수정 사항으로 인하여 타입 캐스팅이 사라진 변수는 기존에 의도했던 타입으로 사용할 수 있도록 아래에 캐스팅 구문을 추가했습니다.