### PR TITLE
이메일 사용자를 위한 익명 이름 생성

### DIFF
--- a/modules/auth.py
+++ b/modules/auth.py
@@ -26,6 +26,9 @@ def authenticate(token: str) -> str | ErrorObject:
     
     uid, name = decoded_data
     
+    if name is None:
+        name = 'Anonymous ' + uid[:4]
+    
     exists = db.is_user_exist(uid)
     if isinstance(exists, db.SQLAlchemyError):
         return ErrorObject(500, "DB Error: " + str(exists))


### PR DESCRIPTION
Google 계정을 사용하여 로그인하는 경우 일어나지 않는 경우이지만 이메일 계정을 사용하여 토큰을 생성하는 경우 Firebase 상 `display_name`이 존재하지 않기 때문에 DB에서 오류가 생길 수 있습니다. 이 경우 uid의 첫 4자리를 활용하여 사용자를 구분하는 방법으로 결정하여 사용자의 이름은 `Anonymous <첫 4자리>`의 형식을 가집니다. 운이 좋다면 최대 약 `62 ^ 4 = 14776336`명의 익명 사용자를 구분할 수 있습니다.